### PR TITLE
Update airtap

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "airtap": "~1.0.0",
+    "airtap": "^2.0.2",
     "is-async-supported": "~1.2.0",
     "run-series": "~1.1.4",
     "tape": "~4.9.0"


### PR DESCRIPTION
This doesn't work yet because browserify 16's shims don't support old IE by default. We can switch back to buffer@4 probably to make it work again.