### PR TITLE
Fixes for Node.js <= 0.12 and Firefox <66

### DIFF
--- a/support/types.js
+++ b/support/types.js
@@ -309,7 +309,7 @@ function isDataViewToString(value) {
 isDataViewToString.working = (
   typeof ArrayBuffer !== 'undefined' &&
   typeof DataView !== 'undefined' &&
-  isDataViewToString(new DataView(new ArrayBuffer()))
+  isDataViewToString(new DataView(new ArrayBuffer(1), 0, 1))
 );
 function isDataView(value) {
   if (typeof DataView === 'undefined') {

--- a/support/types.js
+++ b/support/types.js
@@ -115,7 +115,10 @@ function isUint8Array(value) {
   } else {
     return (
       ObjectToString(value) === '[object Uint8Array]' ||
-      isBuffer(value)
+      // If it's a Buffer instance _and_ has a `.buffer` property,
+      // this is an ArrayBuffer based buffer; thus it's an Uint8Array
+      // (Old Node.js had a custom non-Uint8Array implementation)
+      isBuffer(value) && value.buffer !== undefined
     );
   }
 }

--- a/test/node/index.js
+++ b/test/node/index.js
@@ -1,6 +1,7 @@
 var spawn = require('child_process').spawn;
 var path = require('path');
 var series = require('run-series');
+var assert = require('assert');
 
 function test(filename) {
   return function(cb) {
@@ -9,6 +10,11 @@ function test(filename) {
       cb(code !== 0 ? new Error('test ' + path.basename(filename) + ' failed') : null);
     });
   };
+}
+
+// "polyfill" deepStrictEqual on Node 0.12 and below
+if (!assert.deepStrictEqual) {
+  assert.deepStrictEqual = assert.strictEqual;
 }
 
 series([

--- a/test/node/index.js
+++ b/test/node/index.js
@@ -1,7 +1,6 @@
 var spawn = require('child_process').spawn;
 var path = require('path');
 var series = require('run-series');
-var assert = require('assert');
 
 function test(filename) {
   return function(cb) {
@@ -10,11 +9,6 @@ function test(filename) {
       cb(code !== 0 ? new Error('test ' + path.basename(filename) + ' failed') : null);
     });
   };
-}
-
-// "polyfill" deepStrictEqual on Node 0.12 and below
-if (!assert.deepStrictEqual) {
-  assert.deepStrictEqual = assert.strictEqual;
 }
 
 series([

--- a/test/node/types.js
+++ b/test/node/types.js
@@ -21,7 +21,7 @@ var objectEntries = require('object.entries');
 
 // "polyfill" deepStrictEqual on Node 0.12 and below
 if (!assert.deepStrictEqual) {
-  assert.deepStrictEqual = assert.strictEqual;
+  assert.deepStrictEqual = assert.deepEqual;
 }
 
 function uncurryThis(f) {

--- a/test/node/types.js
+++ b/test/node/types.js
@@ -175,6 +175,9 @@ if (isBuggyFirefox) {
   console.log('skipping fake typed array tests because they do not work in FF')
 }
 
+// Old Node.js had a fully custom Buffer implementation, newer are based on ArrayBuffer
+// This is important for the ArrayBuffer and typed array tests
+var isBufferBasedOnArrayBuffer = Buffer.alloc(1).buffer !== undefined;
 {
   var primitive = function primitive() { return true; };
   var arrayBuffer = function arrayBuffer() { return new ArrayBuffer(1); };
@@ -394,7 +397,7 @@ if (isBuggyFirefox) {
 
   var expected = {
     isArrayBufferView: [
-      buffer,
+      isBufferBasedOnArrayBuffer ? buffer : undefined,
       dataView,
       stealthyDataView,
       uint8Array,
@@ -421,7 +424,7 @@ if (isBuggyFirefox) {
       stealthyBigUint64Array
     ],
     isTypedArray: [
-      buffer,
+      isBufferBasedOnArrayBuffer ? buffer : undefined,
       uint8Array,
       stealthyUint8Array,
       uint8ClampedArray,
@@ -446,7 +449,7 @@ if (isBuggyFirefox) {
       stealthyBigUint64Array
     ],
     isUint8Array: [
-      buffer,
+      isBufferBasedOnArrayBuffer ? buffer : undefined,
       uint8Array,
       stealthyUint8Array
     ],

--- a/test/node/types.js
+++ b/test/node/types.js
@@ -142,7 +142,9 @@ console.log('Testing', 'isBoxedPrimitive');
 
 var SymbolSupported = typeof Symbol !== 'undefined';
 var SymbolToStringTagSupported = SymbolSupported && typeof Symbol.toStringTag !== 'undefined';
-if (SymbolToStringTagSupported) {
+var isBuggyFirefox = typeof navigator !== 'undefined' && /Firefox\/\d+/.test(navigator.userAgent) &&
+  parseInt(navigator.userAgent.split('Firefox/')[1], 10) < 66
+if (SymbolToStringTagSupported && !isBuggyFirefox) {
   [
     'Uint8Array',
     'Uint8ClampedArray',
@@ -168,6 +170,9 @@ if (SymbolToStringTagSupported) {
     assert(!types[method](_defineProperty({}, Symbol.toStringTag, typedArray)));
     assert(types[method](array));
   });
+}
+if (isBuggyFirefox) {
+  console.log('skipping fake typed array tests because they do not work in FF')
 }
 
 {

--- a/test/node/types.js
+++ b/test/node/types.js
@@ -19,6 +19,11 @@ var vm = require('vm');
 var Buffer = require('safe-buffer').Buffer
 var objectEntries = require('object.entries');
 
+// "polyfill" deepStrictEqual on Node 0.12 and below
+if (!assert.deepStrictEqual) {
+  assert.deepStrictEqual = assert.strictEqual;
+}
+
 function uncurryThis(f) {
   return f.call.bind(f);
 }

--- a/test/node/types.js
+++ b/test/node/types.js
@@ -82,7 +82,7 @@ for (var _i = 0, _arr = [
       value: 'foo'
     });
   }, 'isUint8Array'],
-  [function () { return new DataView(new ArrayBuffer(1)); }, 'isDataView'],
+  [function () { return new DataView(new ArrayBuffer(1), 0, 1); }, 'isDataView'],
   [function () { return new SharedArrayBuffer(); }, 'isSharedArrayBuffer'],
   // [ new Proxy({}, {}), 'isProxy' ],
   [function () { return new WebAssembly.Module(wasmBuffer); }, 'isWebAssemblyCompiledModule']
@@ -170,7 +170,7 @@ if (SymbolToStringTagSupported) {
   var arrayBuffer = function arrayBuffer() { return new ArrayBuffer(1); };
 
   var buffer = function buffer() { return Buffer.from(arrayBuffer()); };
-  var dataView = function dataView() { return new DataView(arrayBuffer()); };
+  var dataView = function dataView() { return new DataView(arrayBuffer(), 0, 1); };
   var uint8Array = function uint8Array() { return new Uint8Array(arrayBuffer()); };
   var uint8ClampedArray = function uint8ClampedArray() { return new Uint8ClampedArray(arrayBuffer()); };
   var uint16Array = function uint16Array() { return new Uint16Array(arrayBuffer()); };
@@ -208,7 +208,7 @@ if (SymbolToStringTagSupported) {
   var fakeBigUint64Array = function fakeBigUint64Array() { return Object.create(BigUint64Array.prototype); };
 
   var stealthyDataView = function stealthyDataView() {
-    return Object.setPrototypeOf(new DataView(arrayBuffer()), Uint8Array.prototype);
+    return Object.setPrototypeOf(new DataView(arrayBuffer(), 0, 1), Uint8Array.prototype);
   };
   var stealthyUint8Array = function stealthyUint8Array() {
     return Object.setPrototypeOf(new Uint8Array(arrayBuffer()), ArrayBuffer.prototype);


### PR DESCRIPTION
Old Node.js Buffers were not based on Uint8Array, I think it's best not to pretend that they were. Now isArrayBufferView and isUint8Array will agree on whether a buffer is a typed array (both no for old ones, yes for new ones)

A typed array / Symbol.toStringTag test doesn't work in Firefox 65 and below, it might be a bug there and it's quite an edge case anyway so we'll skip that test for now.