### PR TITLE
IE 11 compatibility when Symbol is polyfilled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ script:
   - 'npm test'
   # Run browser tests on one node version.
   - 'if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${TRAVIS_NODE_VERSION}" = "stable" ]; then npm run test:browsers; fi'
+  - 'if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${TRAVIS_NODE_VERSION}" = "stable" ]; then npm run test:browsers:polyfills; fi'
 addons:
   sauce_connect: true
   hosts:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ script:
   - 'npm test'
   # Run browser tests on one node version.
   - 'if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${TRAVIS_NODE_VERSION}" = "stable" ]; then npm run test:browsers; fi'
-  - 'if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${TRAVIS_NODE_VERSION}" = "stable" ]; then npm run test:browsers:polyfills; fi'
+  - 'if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${TRAVIS_NODE_VERSION}" = "stable" ]; then npm run test:browsers:with-polyfills; fi'
 addons:
   sauce_connect: true
   hosts:

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "airtap": "~1.0.0",
+    "core-js": "^3.6.5",
     "is-async-supported": "~1.2.0",
     "object.assign": "~4.1.0",
     "object.entries": "^1.1.0",
@@ -40,6 +41,8 @@
   "scripts": {
     "test": "node test/node/index.js",
     "test:browsers": "airtap test/browser/index.js",
+    "test:browsers:with-polyfills": "airtap test/browser/with-polyfills.js",
+    "test:browsers:with-polyfills:local": "npm run test:browsers:with-polyfills -- --local",
     "test:browsers:local": "npm run test:browsers -- --local"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "inherits": "^2.0.3",
     "is-arguments": "^1.0.4",
     "is-generator-function": "^1.0.7",
-    "safe-buffer": "^5.1.2"
+    "is-typed-array": "^1.1.3",
+    "safe-buffer": "^5.1.2",
+    "which-typed-array": "^1.1.2"
   },
   "devDependencies": {
     "airtap": "~1.0.0",

--- a/support/types.js
+++ b/support/types.js
@@ -3,10 +3,10 @@
 
 'use strict';
 
-var isBuffer = require('./isBuffer');
-
 var isArgumentsObject = require('is-arguments');
 var isGeneratorFunction = require('is-generator-function');
+var whichTypedArray = require('which-typed-array');
+var isTypedArray = require('is-typed-array');
 
 function uncurryThis(f) {
   return f.call.bind(f);
@@ -14,19 +14,6 @@ function uncurryThis(f) {
 
 var BigIntSupported = typeof BigInt !== 'undefined';
 var SymbolSupported = typeof Symbol !== 'undefined';
-var SymbolToStringTagSupported = SymbolSupported && typeof Symbol.toStringTag !== 'undefined';
-var Uint8ArraySupported = typeof Uint8Array !== 'undefined';
-var ArrayBufferSupported = typeof ArrayBuffer !== 'undefined';
-
-if (Uint8ArraySupported && SymbolToStringTagSupported) {
-  var TypedArrayPrototype = Object.getPrototypeOf(Uint8Array.prototype);
-
-  var TypedArrayProto_toStringTag =
-      uncurryThis(
-        Object.getOwnPropertyDescriptor(TypedArrayPrototype,
-                                        Symbol.toStringTag).get);
-
-}
 
 var ObjectToString = uncurryThis(Object.prototype.toString);
 
@@ -55,8 +42,8 @@ function checkBoxedPrimitive(value, prototypeValueOf) {
 }
 
 exports.isArgumentsObject = isArgumentsObject;
-
 exports.isGeneratorFunction = isGeneratorFunction;
+exports.isTypedArray = isTypedArray;
 
 // Taken from here and modified for better browser support
 // https://github.com/sindresorhus/p-is-promise/blob/cda35a513bda03f977ad5cde3a079d237e82d7ef/index.js
@@ -77,7 +64,7 @@ function isPromise(input) {
 exports.isPromise = isPromise;
 
 function isArrayBufferView(value) {
-  if (ArrayBufferSupported && ArrayBuffer.isView) {
+  if (typeof ArrayBuffer !== 'undefined' && ArrayBuffer.isView) {
     return ArrayBuffer.isView(value);
   }
 
@@ -88,129 +75,59 @@ function isArrayBufferView(value) {
 }
 exports.isArrayBufferView = isArrayBufferView;
 
-function isTypedArray(value) {
-  if (Uint8ArraySupported && SymbolToStringTagSupported) {
-    return TypedArrayProto_toStringTag(value) !== undefined;
-  } else {
-    return (
-      isUint8Array(value) ||
-      isUint8ClampedArray(value) ||
-      isUint16Array(value) ||
-      isUint32Array(value) ||
-      isInt8Array(value) ||
-      isInt16Array(value) ||
-      isInt32Array(value) ||
-      isFloat32Array(value) ||
-      isFloat64Array(value) ||
-      isBigInt64Array(value) ||
-      isBigUint64Array(value)
-    );
-  }
-}
-exports.isTypedArray = isTypedArray;
 
 function isUint8Array(value) {
-  if (Uint8ArraySupported && SymbolToStringTagSupported) {
-    return TypedArrayProto_toStringTag(value) === 'Uint8Array';
-  } else {
-    return (
-      ObjectToString(value) === '[object Uint8Array]' ||
-      // If it's a Buffer instance _and_ has a `.buffer` property,
-      // this is an ArrayBuffer based buffer; thus it's an Uint8Array
-      // (Old Node.js had a custom non-Uint8Array implementation)
-      isBuffer(value) && value.buffer !== undefined
-    );
-  }
+  return whichTypedArray(value) === 'Uint8Array';
 }
 exports.isUint8Array = isUint8Array;
 
 function isUint8ClampedArray(value) {
-  if (Uint8ArraySupported && SymbolToStringTagSupported) {
-    return TypedArrayProto_toStringTag(value) === 'Uint8ClampedArray';
-  } else {
-    return ObjectToString(value) === '[object Uint8ClampedArray]';
-  }
+  return whichTypedArray(value) === 'Uint8ClampedArray';
 }
 exports.isUint8ClampedArray = isUint8ClampedArray;
 
 function isUint16Array(value) {
-  if (Uint8ArraySupported && SymbolToStringTagSupported) {
-    return TypedArrayProto_toStringTag(value) === 'Uint16Array';
-  } else {
-    return ObjectToString(value) === '[object Uint16Array]';
-  }
+  return whichTypedArray(value) === 'Uint16Array';
 }
 exports.isUint16Array = isUint16Array;
 
 function isUint32Array(value) {
-  if (Uint8ArraySupported && SymbolToStringTagSupported) {
-    return TypedArrayProto_toStringTag(value) === 'Uint32Array';
-  } else {
-    return ObjectToString(value) === '[object Uint32Array]';
-  }
+  return whichTypedArray(value) === 'Uint32Array';
 }
 exports.isUint32Array = isUint32Array;
 
 function isInt8Array(value) {
-  if (Uint8ArraySupported && SymbolToStringTagSupported) {
-    return TypedArrayProto_toStringTag(value) === 'Int8Array';
-  } else {
-    return ObjectToString(value) === '[object Int8Array]';
-  }
+  return whichTypedArray(value) === 'Int8Array';
 }
 exports.isInt8Array = isInt8Array;
 
 function isInt16Array(value) {
-  if (Uint8ArraySupported && SymbolToStringTagSupported) {
-    return TypedArrayProto_toStringTag(value) === 'Int16Array';
-  } else {
-    return ObjectToString(value) === '[object Int16Array]';
-  }
+  return whichTypedArray(value) === 'Int16Array';
 }
 exports.isInt16Array = isInt16Array;
 
 function isInt32Array(value) {
-  if (Uint8ArraySupported && SymbolToStringTagSupported) {
-    return TypedArrayProto_toStringTag(value) === 'Int32Array';
-  } else {
-    return ObjectToString(value) === '[object Int32Array]';
-  }
+  return whichTypedArray(value) === 'Int32Array';
 }
 exports.isInt32Array = isInt32Array;
 
 function isFloat32Array(value) {
-  if (Uint8ArraySupported && SymbolToStringTagSupported) {
-    return TypedArrayProto_toStringTag(value) === 'Float32Array';
-  } else {
-    return ObjectToString(value) === '[object Float32Array]';
-  }
+  return whichTypedArray(value) === 'Float32Array';
 }
 exports.isFloat32Array = isFloat32Array;
 
 function isFloat64Array(value) {
-  if (Uint8ArraySupported && SymbolToStringTagSupported) {
-    return TypedArrayProto_toStringTag(value) === 'Float64Array';
-  } else {
-    return ObjectToString(value) === '[object Float64Array]';
-  }
+  return whichTypedArray(value) === 'Float64Array';
 }
 exports.isFloat64Array = isFloat64Array;
 
 function isBigInt64Array(value) {
-  if (Uint8ArraySupported && SymbolToStringTagSupported) {
-    return TypedArrayProto_toStringTag(value) === 'BigInt64Array';
-  } else {
-    return ObjectToString(value) === '[object BigInt64Array]';
-  }
+  return whichTypedArray(value) === 'BigInt64Array';
 }
 exports.isBigInt64Array = isBigInt64Array;
 
 function isBigUint64Array(value) {
-  if (Uint8ArraySupported && SymbolToStringTagSupported) {
-    return TypedArrayProto_toStringTag(value) === 'BigUint64Array';
-  } else {
-    return ObjectToString(value) === '[object BigUint64Array]';
-  }
+  return whichTypedArray(value) === 'BigUint64Array';
 }
 exports.isBigUint64Array = isBigUint64Array;
 
@@ -405,7 +322,7 @@ function isBoxedPrimitive(value) {
 exports.isBoxedPrimitive = isBoxedPrimitive;
 
 function isAnyArrayBuffer(value) {
-  return Uint8ArraySupported && (
+  return typeof Uint8Array !== 'undefined' && (
     isArrayBuffer(value) ||
     isSharedArrayBuffer(value)
   );

--- a/support/types.js
+++ b/support/types.js
@@ -195,13 +195,6 @@ isWeakSetToString.working = (
 );
 function isWeakSet(value) {
   return isWeakSetToString(value);
-  if (typeof WeakSet === 'undefined') {
-    return false;
-  }
-
-  return isWeakSetToString.working
-    ? isWeakSetToString(value)
-    : value instanceof WeakSet;
 }
 exports.isWeakSet = isWeakSet;
 

--- a/test/browser/with-polyfills.js
+++ b/test/browser/with-polyfills.js
@@ -1,0 +1,2 @@
+require('core-js');
+require('./index.js');


### PR DESCRIPTION
Resolves #40.

Currently, with a Symbol polyfill present in IE 11, requiring `util/types` throws (see #40 for more detail). With `Symbol` and `Symbol.toStringTag` available, IE 11 then attempts to use it on the Uint8Array prototype, where it does not exist.

This:
* Adds another set of tests with polyfills present in the environment. I'm happy to restrict this to just the Symbol polyfill as that should be all that's necessary to reproduce the issue. This additional set of tests was also added to the travis configuration to run in Sauce Labs.
* This follows @ljharb's advice in #40 and uses `is-typed-array` and `which-typed-array` to determine if values are typed arrays and which type they are.

Ideally this is published in a patch release or https://github.com/browserify/commonjs-assert is updated to use it, as folks seem to run into this through their use of `assert` (though it's certainly possible to use `util/types` directly).

cc @mischnic @devongovett @padmaia @stacylondon

Test Plan: Ran both sets of tests (with and without polyfills) in IE 11 with success.