### PR TITLE
Travis-ci: added support for ppc64le & Removed unsupported versions for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,50 @@ jobs:
       node_js: lts/*
       script: npm run test:browsers:with-polyfills
       addons: *AIRTAP
+#Added power jobs
+    - name: Run tests on stable Node.js
+      arch: ppc64le
+      node_js: stable
+      script: npm test
+    - name: Run tests on Node.js 12
+      arch: ppc64le
+      node_js: 12
+      script: npm test
+    - name: Run tests on Node.js 10
+      arch: ppc64le
+      node_js: 10
+      script: npm test
+    - name: Run tests on Node.js 8
+      arch: ppc64le
+      node_js: 8
+      script: npm test
+    - name: Run tests on Node.js 6
+      arch: ppc64le
+      node_js: 6
+      script: npm test
+    - name: Run tests on Node.js 4
+      arch: ppc64le
+      node_js: 4
+      script: npm test
+    - name: Run browser tests
+      arch: ppc64le
+      node_js: lts/*
+      script: npm run test:browsers
+      addons: *AIRTAP
+    - name: Run browser tests with polyfilled environment
+      arch: ppc64le
+      node_js: lts/*
+      script: npm run test:browsers:with-polyfills
+      addons: *AIRTAP
+  exclude:
+    - name: Run tests on Node.js 0.12
+      arch: ppc64le
+      node_js: '0.12'
+      script: npm test
+    - name: Run tests on Node.js 0.10
+      arch: ppc64le
+      node_js: '0.10'
+      script: npm test    
 
 env:
   global:


### PR DESCRIPTION
Hi,

I had added ppc64le(Linux on Power) architecture & Removed unsupported versions for ppc64le support on Travis-CI in the PR and looks like its been successfully added.

Reason behind running tests on ppc64le: This package is included in the ppc64le versions of RHEL and Ubuntu - this allows the top of tree to be tested continuously as it is for Intel, making it easier to catch any possible regressions on ppc64le before the distros begin their clones and builds. This reduces the work in integrating this package into future versions of RHEL/Ubuntu.

Regards,
Devendra