### PR TITLE
Added process npm package dependency to fix the ReferenceError

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "is-arguments": "^1.0.4",
     "is-generator-function": "^1.0.7",
     "is-typed-array": "^1.1.3",
+    "process": "^0.11.10",
     "safe-buffer": "^5.1.2",
     "which-typed-array": "^1.1.2"
   },

--- a/util.js
+++ b/util.js
@@ -19,6 +19,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+var process = require('process');
+
 var getOwnPropertyDescriptors = Object.getOwnPropertyDescriptors ||
   function getOwnPropertyDescriptors(obj) {
     var keys = Object.keys(obj);


### PR DESCRIPTION
Adding npm package dependency for `process` package

### Resolves Issue
- https://github.com/browserify/node-util/issues/43

### What does it fixes
- Fixes `ReferenceError: process is not defined` in browser and while bundling with Webpack 5.


