### PR TITLE
fix: avoid SharedArrayBuffer until required

### DIFF
--- a/support/types.js
+++ b/support/types.js
@@ -236,7 +236,7 @@ function isDataView(value) {
 exports.isDataView = isDataView;
 
 // Store a copy of SharedArrayBuffer in case it's deleted elsewhere
-var SharedArrayBufferCopy = SharedArrayBuffer;
+var SharedArrayBufferCopy = typeof SharedArrayBuffer !== 'undefined' ? SharedArrayBuffer : undefined;
 function isSharedArrayBufferToString(value) {
   return ObjectToString(value) === '[object SharedArrayBuffer]';
 }

--- a/support/types.js
+++ b/support/types.js
@@ -235,32 +235,23 @@ function isDataView(value) {
 }
 exports.isDataView = isDataView;
 
+// Store a copy of SharedArrayBuffer in case it's deleted elsewhere
+var SharedArrayBufferCopy = SharedArrayBuffer;
 function isSharedArrayBufferToString(value) {
   return ObjectToString(value) === '[object SharedArrayBuffer]';
 }
-// Avoid invoking SharedArrayBuffer constructor until required, then memoize
-Object.defineProperty(isSharedArrayBufferToString, 'working', {
-  get: (function() {
-    var isWorking;
-    return function () {
-      if (isWorking === undefined) {
-        isWorking = (
-          typeof SharedArrayBuffer !== 'undefined' &&
-          isSharedArrayBufferToString(new SharedArrayBuffer())
-        )
-      }
-      return isWorking;
-    }
-  })()
-});
 function isSharedArrayBuffer(value) {
-  if (typeof SharedArrayBuffer === 'undefined') {
+  if (typeof SharedArrayBufferCopy === 'undefined') {
     return false;
+  }
+
+  if (typeof isSharedArrayBufferToString.working === 'undefined') {
+    isSharedArrayBufferToString.working = isSharedArrayBufferToString(new SharedArrayBufferCopy());
   }
 
   return isSharedArrayBufferToString.working
     ? isSharedArrayBufferToString(value)
-    : value instanceof SharedArrayBuffer;
+    : value instanceof SharedArrayBufferCopy;
 }
 exports.isSharedArrayBuffer = isSharedArrayBuffer;
 

--- a/support/types.js
+++ b/support/types.js
@@ -238,10 +238,21 @@ exports.isDataView = isDataView;
 function isSharedArrayBufferToString(value) {
   return ObjectToString(value) === '[object SharedArrayBuffer]';
 }
-isSharedArrayBufferToString.working = (
-  typeof SharedArrayBuffer !== 'undefined' &&
-  isSharedArrayBufferToString(new SharedArrayBuffer())
-);
+// Avoid invoking SharedArrayBuffer constructor until required, then memoize
+Object.defineProperty(isSharedArrayBufferToString, 'working', {
+  get: (function() {
+    var isWorking;
+    return function () {
+      if (isWorking === undefined) {
+        isWorking = (
+          typeof SharedArrayBuffer !== 'undefined' &&
+          isSharedArrayBufferToString(new SharedArrayBuffer())
+        )
+      }
+      return isWorking;
+    }
+  })()
+});
 function isSharedArrayBuffer(value) {
   if (typeof SharedArrayBuffer === 'undefined') {
     return false;


### PR DESCRIPTION
@goto-bus-stop 

We are auditing uses of `SharedArrayBuffer` per https://developers.google.com/search/blog/2021/03/sharedarraybuffer-notes which is a vector for some timing attacks https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/ 

One of the uses of `SharedArrayBuffer` on our site  is from this module.

The type check for `isSharedArrayBufferToString` has an eager calculation for if `SharedArrayBuffer` exists which invokes the constructor, triggering the warning. Simply calling `require('util');` is enough to trigger the warning.

This PR moves that eager calculation to a lazy, but memoized, calculation which would prevent the warning unless there is some code explicitly calling `isSharedArrayBuffer`. If there is such code, I would certainly like to know that specifically, rather than just knowing every time someone has included the `util` module.

This does add some overhead / lines of code with the memoized function so I can understand any reservations, but this would make auditing sites a heck of a lot easier.

Thanks!