### PR TITLE
chore: release v0.12.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.12.4
+* Avoid SharedArrayBuffer until required. ([@snyamathi](https://github.com/snyamathi) in [#59](https://github.com/browserify/node-util/pull/59))
+
+  This fixes a [security warning](https://developers.google.com/search/blog/2021/03/sharedarraybuffer-notes) for SharedArrayBuffer.
+
 ## 0.12.3
 * Use robust `which-typed-array`, `is-typed-array` modules for the `util.types.isTypedArray` family of functions. ([@wbinnssmith](https://github.com/wbinnssmith) in [#47](https://github.com/browserify/node-util/pull/47))
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "util",
   "description": "Node.js's util module for all engines",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "author": {
     "name": "Joyent",
     "url": "http://www.joyent.com"


### PR DESCRIPTION
@goto-bus-stop Hoping to get [#59](https://github.com/browserify/node-util/pull/59) released when you have some time - here's the CHANGELOG for your convenience. Thanks!