### PR TITLE
Avoid multiple declarations of `fn` in promisify

### DIFF
--- a/util.js
+++ b/util.js
@@ -614,14 +614,14 @@ exports.promisify = function promisify(original) {
     throw new TypeError('The "original" argument must be of type Function');
 
   if (kCustomPromisifiedSymbol && original[kCustomPromisifiedSymbol]) {
-    var fn = original[kCustomPromisifiedSymbol];
-    if (typeof fn !== 'function') {
+    var customPromisifiedFn = original[kCustomPromisifiedSymbol];
+    if (typeof customPromisifiedFn !== 'function') {
       throw new TypeError('The "util.promisify.custom" argument must be of type Function');
     }
-    Object.defineProperty(fn, kCustomPromisifiedSymbol, {
-      value: fn, enumerable: false, writable: false, configurable: true
+    Object.defineProperty(customPromisifiedFn, kCustomPromisifiedSymbol, {
+      value: customPromisifiedFn, enumerable: false, writable: false, configurable: true
     });
-    return fn;
+    return customPromisifiedFn;
   }
 
   function fn() {


### PR DESCRIPTION
I'm having some issues with using this package in swc-loader which stems from the below lines. 

https://github.com/browserify/node-util/blob/a292d8a73ac877cc9a0ae64b287cc064dcbacb54/util.js#L616-L629

We've got two declarations of `fn` here which share the same scope (despite the fact that we can only encounter one of them) and this is triggering a build error as a result.

Failing CI build demonstrating this [here](https://github.com/TomAFrench/actual/runs/6654734569?check_suite_focus=true#step:6:310)

As we're restricted to `var` in order to support ES5, I've renamed one of these instances of `fn` to something that seems reasonable.